### PR TITLE
Add in-memory store

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -4,47 +4,30 @@ import tw from "tailwind.macro";
 import { jsx } from "@emotion/core";
 import { ExportTable, SummaryTable } from "./Components/SummaryTables";
 import AddBudgetItem from "./Components/AddBudgetItem";
+import { addItem, removeItem, setAllExported, getPendingItems } from "./Components/InMemoryStore";
 import { Switch, Route, Link } from "react-router-dom";
 
 function App() {
   const [dataToExport, setDataToExport] = useState([]);
 
-  const addRowToExport = ({ date, reportingdate, currency, location, category, subcategory, to, amount, details, project }) => {
-    const newData = dataToExport.slice();
-    //TODO: Remove this
-    const id = Math.random() * 500000;
-    newData.push({
-      id, date, reportingdate, currency, location, category, subcategory, to, amount, details, project
-    });
-    setDataToExport(newData);
+  const addRowToExport = (item) => {
+    addItem(item);
+    setDataToExport(getPendingItems());
   }
 
   const deleteItem = (id) => {
-    const newData = dataToExport.filter(d => d.id !== id);
-    setDataToExport(newData);
+    removeItem(id);
+    setDataToExport(getPendingItems());
   }
 
   const markDataAsExported = () => {
-    setDataToExport([]);
+    setAllExported();
+    setDataToExport(getPendingItems());
   }
 
-  const todayAsDefault = new Date().toISOString().substr(0, 10);
-
   useEffect(() => {
-    // TODO: Remove this fake item
-    addRowToExport({
-      date: todayAsDefault,
-      reportingdate: todayAsDefault,
-      currency: "USD",
-      location: "New York",
-      category: "Food",
-      subcategory: "Cafe",
-      to: "Starbucks",
-      amount: 9.99,
-      details: "",
-      project: ""
-    });
-  },[])
+    setDataToExport(getPendingItems());
+  },[]);
 
   return (
     <div css={tw`min-h-screen flex flex-col font-sansmx-auto ml-12 m-0 p-6`}>

--- a/src/Components/InMemoryStore/index.js
+++ b/src/Components/InMemoryStore/index.js
@@ -1,0 +1,39 @@
+let items = [];
+
+const getPendingItems = () => {
+  return items.slice();
+}
+
+const addItem = ({date, reportingdate, currency, location, category, subcategory, to, amount, details, project}) => {
+  const id = Math.random() * 500000;
+  items.push({
+    id, date, reportingdate, currency, location, category, subcategory, to, amount, details, project
+  });
+  console.log(items)
+};
+
+const removeItem = (id) => {
+  items = items.filter(d => d.id !== id);
+};
+
+const setAllExported = () => {
+  items = [];
+};
+
+// Seed the store with a fake item
+const todayAsDefault = new Date().toISOString().substr(0, 10);
+
+addItem({
+  date: todayAsDefault,
+  reportingdate: todayAsDefault,
+  currency: "USD",
+  location: "New York",
+  category: "Food",
+  subcategory: "Cafe",
+  to: "Starbucks",
+  amount: 9.99,
+  details: "",
+  project: ""
+});
+
+export { getPendingItems, addItem, removeItem, setAllExported };


### PR DESCRIPTION
While developing we'll be using an in-memory store, but when deployed we'll use firestore (or another cloud based data store).  This PR sets up the API we'll use to interact with it, and refactors the app to use that.

A few things you'll notice here:
- API symmetry - rather than add/delete we now have add/remove (opposite verb should be the antonym)
- More consistent naming (get/set)
- Added an API for the get which was missing
- We keep passing the 'item' around until the end, only destructuring inside the final part of the API

Right now the app is going to keep it simple and assume after every data manipulation we go back to the store to 'get' all the pending items again (rather than being smart and updating the state based on the work we just did).

Some items that are notably missing from the API at this stage are update, and getAll (though we're also missing a way to visualise the getAll!).

Next up is a way to mark items as exported or not, so the getPending can actually filter and return a subset.