### PR TITLE
Export filtering

### DIFF
--- a/src/Components/InMemoryStore/index.js
+++ b/src/Components/InMemoryStore/index.js
@@ -1,7 +1,7 @@
 let items = [];
 
 const getPendingItems = () => {
-  return items.slice();
+  return items.filter(i => !i.exported);
 }
 
 const addItem = ({date, reportingdate, currency, location, category, subcategory, to, amount, details, project}) => {
@@ -9,7 +9,6 @@ const addItem = ({date, reportingdate, currency, location, category, subcategory
   items.push({
     id, date, reportingdate, currency, location, category, subcategory, to, amount, details, project
   });
-  console.log(items)
 };
 
 const removeItem = (id) => {
@@ -20,7 +19,7 @@ const setAllExported = () => {
   items = [];
 };
 
-// Seed the store with a fake item
+// Seed the store with a few fake items
 const todayAsDefault = new Date().toISOString().substr(0, 10);
 
 addItem({
@@ -35,5 +34,21 @@ addItem({
   details: "",
   project: ""
 });
+
+addItem({
+  date: todayAsDefault,
+  reportingdate: todayAsDefault,
+  currency: "USD",
+  location: "New York",
+  category: "Food",
+  subcategory: "Restaurant",
+  to: "Chiptole",
+  amount: 12.49,
+  details: "",
+  project: ""
+});
+
+items[1].exported = true;
+
 
 export { getPendingItems, addItem, removeItem, setAllExported };

--- a/src/Components/InMemoryStore/index.js
+++ b/src/Components/InMemoryStore/index.js
@@ -7,7 +7,7 @@ const getPendingItems = () => {
 const addItem = ({date, reportingdate, currency, location, category, subcategory, to, amount, details, project}) => {
   const id = Math.random() * 500000;
   items.push({
-    id, date, reportingdate, currency, location, category, subcategory, to, amount, details, project
+    id, date, reportingdate, currency, location, category, subcategory, to, amount, details, project, exported: false
   });
 };
 
@@ -16,7 +16,11 @@ const removeItem = (id) => {
 };
 
 const setAllExported = () => {
-  items = [];
+  items.map((item, i) => {
+    if(!item.exported) {
+      items[i].exported = true;
+    }
+  });
 };
 
 // Seed the store with a few fake items


### PR DESCRIPTION
Rather than emptying the array each time we now look for the `exported` property, which is initialized to `false` on every new item (we do this to keep the code simple - when looking in our cloud data store we may need to be slightly more robust and assume this property may be absent).

The map code needlessly indexes back into the array rather than modifying the object, don't ask me why ¯\_(ツ)_/¯

We add a new object at startup which defaults to exported to ensure we don't render two items (we should only see the Starbucks item, not the Chiptole one).