### PR TITLE
Environment driven store

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -4113,6 +4113,58 @@
         "sha.js": "^2.4.8"
       }
     },
+    "cross-env": {
+      "version": "6.0.3",
+      "resolved": "https://registry.npmjs.org/cross-env/-/cross-env-6.0.3.tgz",
+      "integrity": "sha512-+KqxF6LCvfhWvADcDPqo64yVIB31gv/jQulX2NGzKS/g3GEVz6/pt4wjHFtFWsHMddebWD/sDthJemzM4MaAag==",
+      "dev": true,
+      "requires": {
+        "cross-spawn": "^7.0.0"
+      },
+      "dependencies": {
+        "cross-spawn": {
+          "version": "7.0.1",
+          "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.1.tgz",
+          "integrity": "sha512-u7v4o84SwFpD32Z8IIcPZ6z1/ie24O6RU3RbtL5Y316l3KuHVPx9ItBgWQ6VlfAFnRnTtMUrsQ9MUUTuEZjogg==",
+          "dev": true,
+          "requires": {
+            "path-key": "^3.1.0",
+            "shebang-command": "^2.0.0",
+            "which": "^2.0.1"
+          }
+        },
+        "path-key": {
+          "version": "3.1.1",
+          "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+          "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+          "dev": true
+        },
+        "shebang-command": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+          "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+          "dev": true,
+          "requires": {
+            "shebang-regex": "^3.0.0"
+          }
+        },
+        "shebang-regex": {
+          "version": "3.0.0",
+          "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+          "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+          "dev": true
+        },
+        "which": {
+          "version": "2.0.2",
+          "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+          "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+          "dev": true,
+          "requires": {
+            "isexe": "^2.0.0"
+          }
+        }
+      }
+    },
     "cross-spawn": {
       "version": "6.0.5",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-6.0.5.tgz",
@@ -9120,12 +9172,6 @@
         "readable-stream": "^2.0.1"
       }
     },
-    "memorystream": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/memorystream/-/memorystream-0.3.1.tgz",
-      "integrity": "sha1-htcJCzDORV1j+64S3aUaR93K+bI=",
-      "dev": true
-    },
     "merge-anything": {
       "version": "2.4.4",
       "resolved": "https://registry.npmjs.org/merge-anything/-/merge-anything-2.4.4.tgz",
@@ -9567,23 +9613,6 @@
       "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-3.3.0.tgz",
       "integrity": "sha512-U+JJi7duF1o+u2pynbp2zXDW2/PADgC30f0GsHZtRh+HOcXHnw137TrNlyxxRvWW5fjKd3bcLHPxofWuCjaeZg=="
     },
-    "npm-run-all": {
-      "version": "4.1.5",
-      "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.5.tgz",
-      "integrity": "sha512-Oo82gJDAVcaMdi3nuoKFavkIHBRVqQ1qvMb+9LHk/cF4P6B2m8aP04hGf7oL6wZ9BuGwX1onlLhpuoofSyoQDQ==",
-      "dev": true,
-      "requires": {
-        "ansi-styles": "^3.2.1",
-        "chalk": "^2.4.1",
-        "cross-spawn": "^6.0.5",
-        "memorystream": "^0.3.1",
-        "minimatch": "^3.0.4",
-        "pidtree": "^0.3.0",
-        "read-pkg": "^3.0.0",
-        "shell-quote": "^1.6.1",
-        "string.prototype.padend": "^3.0.0"
-      }
-    },
     "npm-run-path": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
@@ -10024,12 +10053,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha1-Ywn04OX6kT7BxpMHrjZLSzd8nns="
-    },
-    "pidtree": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/pidtree/-/pidtree-0.3.0.tgz",
-      "integrity": "sha512-9CT4NFlDcosssyg8KVFltgokyKZIFjoBxw8CTGy+5F38Y1eQWrt8tRayiUOXE+zVKQnYu5BR8JjCtvK3BcnBhg==",
-      "dev": true
     },
     "pify": {
       "version": "3.0.0",
@@ -12751,17 +12774,6 @@
       "requires": {
         "is-fullwidth-code-point": "^2.0.0",
         "strip-ansi": "^4.0.0"
-      }
-    },
-    "string.prototype.padend": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
-      "integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
-      "dev": true,
-      "requires": {
-        "define-properties": "^1.1.2",
-        "es-abstract": "^1.4.3",
-        "function-bind": "^1.0.2"
       }
     },
     "string_decoder": {

--- a/package.json
+++ b/package.json
@@ -15,10 +15,9 @@
     "styled-components": "^4.4.1"
   },
   "scripts": {
-    "start": "npm-run-all --parallel start:react",
-    "build": "npm-run-all build:react",
-    "start:react": "react-scripts start",
-    "build:react": "react-scripts build",
+    "start:firestore": "react-scripts start",
+    "start:inmemory": "cross-env REACT_APP_MEMORY=1 react-scripts start",
+    "build": "react-scripts build",
     "prettier": "prettier --write src/**/*.js",
     "test": "react-scripts test",
     "eject": "react-scripts eject"
@@ -39,7 +38,7 @@
     ]
   },
   "devDependencies": {
-    "npm-run-all": "^4.1.5",
+    "cross-env": "^6.0.3",
     "prettier": "^1.19.1"
   }
 }

--- a/src/Components/Store/index.js
+++ b/src/Components/Store/index.js
@@ -1,16 +1,40 @@
 import {
-  getPendingItems,
-  getItem,
-  addItem,
-  removeItem,
-  updateItem,
-  setAllExported,
-  getCategories,
-  getSpeedyAdd,
-  getTotalSpendForMonth,
-  getRecent,
+  getPendingItems as memory_getPendingItems,
+  getItem as memory_getItem,
+  addItem as memory_addItem,
+  removeItem as memory_removeItem,
+  updateItem as memory_updateItem,
+  setAllExported as memory_setAllExported,
+  getCategories as memory_getCategories,
+  getSpeedyAdd as memory_getSpeedyAdd,
+  getTotalSpendForMonth as memory_getTotalSpendForMonth,
+  getRecent as memory_getRecent
+} from "./inMemoryStore";
+
+import {
+  getPendingItems as firestore_getPendingItems,
+  getItem as firestore_getItem,
+  addItem as firestore_addItem,
+  removeItem as firestore_removeItem,
+  updateItem as firestore_updateItem,
+  setAllExported as firestore_setAllExported,
+  getCategories as firestore_getCategories,
+  getSpeedyAdd as firestore_getSpeedyAdd,
+  getTotalSpendForMonth as firestore_getTotalSpendForMonth,
+  getRecent as firestore_getRecent
 } from "./firebaseStore";
-// } from "./inMemoryStore";
+
+const getPendingItems = process.env.REACT_APP_MEMORY ? memory_getPendingItems : firestore_getPendingItems;
+const getItem  = process.env.REACT_APP_MEMORY ? memory_getItem : firestore_getItem;
+const addItem  = process.env.REACT_APP_MEMORY ? memory_addItem : firestore_addItem;
+const removeItem = process.env.REACT_APP_MEMORY ? memory_removeItem : firestore_removeItem;
+const updateItem = process.env.REACT_APP_MEMORY ? memory_updateItem : firestore_updateItem;
+const setAllExported = process.env.REACT_APP_MEMORY ? memory_setAllExported : firestore_setAllExported;
+const getCategories = process.env.REACT_APP_MEMORY ? memory_getCategories : firestore_getCategories;
+const getSpeedyAdd = process.env.REACT_APP_MEMORY ? memory_getSpeedyAdd : firestore_getSpeedyAdd;
+const getTotalSpendForMonth = process.env.REACT_APP_MEMORY ? memory_getTotalSpendForMonth : firestore_getTotalSpendForMonth;
+const getRecent = process.env.REACT_APP_MEMORY ? memory_getRecent : firestore_getRecent;
+
 
 export {
   getPendingItems,
@@ -22,5 +46,5 @@ export {
   getCategories,
   getSpeedyAdd,
   getTotalSpendForMonth,
-  getRecent,
+  getRecent
 };


### PR DESCRIPTION
Instead of changing the comment for the store, it is now driven by the presence (or absence) of the environment variable `REACT_APP_MEMORY`.

Uses the `cross-env` package so setting environment variables will work on both Windows & Mac:
https://www.npmjs.com/package/cross-env

Variable name prefixed with REACT_APP as that's what is exposed by create-react-app for us:
https://create-react-app.dev/docs/adding-custom-environment-variables/

The code to do the export looks really ugly, and is done this way to work around limitations (can't have a dynamic top-level import statement).  There are probably far better ways of doing this (without quite so much copy-paste), but it works, and should let us stop hitting firestore so often in dev.